### PR TITLE
chore(dependabot): add 30-day cooldown to github-actions ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,6 +19,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 30
     open-pull-requests-limit: 10
     reviewers:
       - "lirantal"


### PR DESCRIPTION
Adds (or normalizes to) `cooldown.default-days: 30` on the github-actions ecosystem entry in `.github/dependabot.yml`. Mirrors the canonical change from lirantal/gh-cp.