### PR TITLE
chore(dependabot): adopt canonical config with 30-day cooldowns

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,29 +1,56 @@
 version: 2
 updates:
-  # Enable version updates for npm
+  - package-ecosystem: "github-actions"
+    directory: ".github/workflows"
+    schedule:
+      interval: "monthly"
+    commit-message:
+      # Prefix all commit messages with "chore: "
+      prefix: "chore"
+    open-pull-requests-limit: 10
+    cooldown:
+      default-days: 30
+    # Use the 'dependencies' default label and add
+    # the 'automerge' one for automerge github action support
+    labels:
+      - "dependencies"
+      - "automerge"
+
   - package-ecosystem: "npm"
     directory: "/"
+    commit-message:
+      # Prefix all commit messages with "chore: "
+      prefix: "chore"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10
-    reviewers:
-      - "lirantal"
-    assignees:
-      - "lirantal"
-    commit-message:
-      prefix: "chore"
-      include: "scope"
+    cooldown:
+      default-days: 30
+      semver-major-days: 30
+      semver-minor-days: 30
+      semver-patch-days: 30
+    # Use the 'dependencies' default label and add
+    # the 'automerge' one for automerge github action support
+    labels:
+      - "dependencies"
+      - "automerge"
+    groups:
+      # Production dependencies without breaking changes
+      dependencies:
+        dependency-type: "production"
+        update-types:
+        - "minor"
+        - "patch"
+      # Production dependencies with breaking changes
+      dependencies-major:
+        dependency-type: "production"
+        update-types:
+        - "major"
+      # Development dependencies
+      dev-dependencies:
+        dependency-type: "development"
+    # example for ignoring dependencies:
+    # ignore:
+    #   - dependency-name: tap
+    #     update-types: ["version-update:semver-major"]
 
-  # Enable version updates for GitHub Actions
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 10
-    reviewers:
-      - "lirantal"
-    assignees:
-      - "lirantal"
-    commit-message:
-      prefix: "chore"
-      include: "scope"


### PR DESCRIPTION
Replaces `.github/dependabot.yml` with the canonical config from create-node-lib (mirrored across all my repos for consistency). Cooldown is set to 30 days everywhere.